### PR TITLE
Provide dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:focal
+# receive build-arguments 
+ARG GH_TOKEN 
+ARG username
+ARG email
+# set GH_TOKEN as env variable 
+ENV GH_TOKEN=${GH_TOKEN}
+# install git
+RUN apt update -y && apt install git -y
+# install gpg
+RUN apt update -y && apt install gpg -y
+# install GitHub CLI (gh)
+RUN type -p curl >/dev/null || apt install curl -y
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+    && apt update \
+    && apt install gh -y
+# clone repo 
+RUN gh repo clone themaxens/ball-bearings-with-quarkus
+# setup git
+WORKDIR /ball-bearings-with-quarkus
+RUN git config gpg.program gpg
+# RUN git config commit.gpgsign true
+RUN git config user.name "${username}"
+RUN git config user.email "${email}"
+# install curl 
+RUN apt-get install -y curl
+RUN curl -Ls https://sh.jbang.dev | bash -s - trust add https://repo1.maven.org/maven2/io/quarkus/quarkus-cli/ 
+RUN curl -Ls https://sh.jbang.dev | bash -s - app install --fresh --force quarkus@quarkusio
+CMD ["bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,9 @@ ENV GH_TOKEN=${GH_TOKEN}
 RUN apt update -y && apt install git -y
 # install gpg
 RUN apt update -y && apt install gpg -y
-# install GitHub CLI (gh)
+# install curl
 RUN type -p curl >/dev/null || apt install curl -y
+# install GitHub CLI (gh)
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
     && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
@@ -26,8 +27,7 @@ RUN git config gpg.program gpg
 # RUN git config commit.gpgsign true
 RUN git config user.name "${username}"
 RUN git config user.email "${email}"
-# install curl 
-RUN apt-get install -y curl
 RUN curl -Ls https://sh.jbang.dev | bash -s - trust add https://repo1.maven.org/maven2/io/quarkus/quarkus-cli/ 
 RUN curl -Ls https://sh.jbang.dev | bash -s - app install --fresh --force quarkus@quarkusio
+EXPOSE 8080
 CMD ["bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | d
     && apt install gh -y
 # clone repo 
 RUN gh repo clone themaxens/ball-bearings-with-quarkus
+# configure git to use GitHub CLI as a credential helper
+RUN gh auth setup-git
 # setup git
 WORKDIR /ball-bearings-with-quarkus
 RUN git config gpg.program gpg

--- a/gen-key-script
+++ b/gen-key-script
@@ -1,0 +1,8 @@
+Key-Type: 1
+Key-Length: 4096
+Subkey-Type: 1
+Subkey-Length: 4096
+Name-Real: REPLACE-ME
+Name-Email: REPLACE-ME
+Expire-Date: 0
+Passphrase: REPLACE-ME


### PR DESCRIPTION
I created a Dockerfile for automatic container creation.

Replace the variables in <> with your personal values:
`docker build --build-arg GH_TOKEN=<token> --build-arg username=<your-username> --build-arg email=<your-email> -t quarkus_image .`

Afterwards you can run the container (quarkus): 
`docker run --name quarkus -it quarkus_image`

The created container contains all dependencies (e.g. git, quarkus). The creation of the GPG-key for signing your commits has to be done manually. 

The creation of the GPG-key can be done with the script "gen-key-script", search for "REPLACE-ME" and enter the correct values for your purpose: 
`gpg --batch --gen-key gen-key-script`

fix #19 